### PR TITLE
Encoding error fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If your chat contains more than tow participants, simply list all their username
 ```sh
 ./kbe.py zapashcanon,emersion,facepalmer
 ``
+
 For group chats, try this repo: https://github.com/eilvelia/keybase-export
 
 ## License

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ kbe is a python script to export [Keybase] chats.
 
 ## Usage
 
+On Windows, make sure that filenames with the `.py` extension will open in Python by default (not in your text editor).
+
 Let's assume your keybase username is `zapashcanon` and that you have a chat with someone named `emersion`, to export this chat, you can just:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Let's assume your keybase username is `zapashcanon` and that you have a chat wit
 
 It will create a folder `zapashcanon,emersion` in which you'll find a JSON file containing raw logs, a `.log` file containing human-readable export of the chat. It'll also download all attachments of the chat and put them in that same folder.
 
-If your chat contains more than tow participants, simply list all their usernames after your own:
+If your chat contains more than two participants, simply list all their usernames after your own:
 
 ```sh
 ./kbe.py zapashcanon,emersion,facepalmer

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Let's assume your keybase username is `zapashcanon` and that you have a chat wit
 
 It will create a folder `zapashcanon,emersion` in which you'll find a JSON file containing raw logs, a `.log` file containing human-readable export of the chat. It'll also download all attachments of the chat and put them in that same folder.
 
+If your chat contains more than tow participants, simply list all their usernames after your own:
+
+```sh
+./kbe.py zapashcanon,emersion,facepalmer
+``
+For group chats, try this repo: https://github.com/eilvelia/keybase-export
+
 ## License
 
 See [LICENSE].

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If your chat contains more than tow participants, simply list all their username
 
 ```sh
 ./kbe.py zapashcanon,emersion,facepalmer
-``
+```
 
 For group chats, try this repo: https://github.com/eilvelia/keybase-export
 

--- a/kbe.py
+++ b/kbe.py
@@ -10,6 +10,9 @@ import tempfile
 import typing
 from datetime import datetime
 
+sys.stdin.reconfigure(encoding='utf-8')
+sys.stdout.reconfigure(encoding='utf-8')
+
 ap = argparse.ArgumentParser()
 ap.add_argument("conv_name", help="Conversation name")
 ap.add_argument(
@@ -128,7 +131,7 @@ log_out = os.path.join(conv_dir, "conv.log")
 
 json_out: typing.Optional[typing.IO[str]] = None
 if save_json:
-    json_out = open(os.path.join(conv_dir, "conv.json"), "w")
+    json_out = open(os.path.join(conv_dir, "conv.json"), "w", encoding="utf-8")
 
 
 def run_query(q):
@@ -242,7 +245,7 @@ print("exporting messages...", file=sys.stderr)
 query = build_query(conv_name, pagination_size=pg)
 last_page = None
 
-with tempfile.NamedTemporaryFile("w+", dir=conv_dir) as tf:
+with tempfile.NamedTemporaryFile("w+", dir=conv_dir, encoding="utf-8") as tf:
     while next_page := outputmsgs(query, dest=tf):
         if not next_page:
             break
@@ -259,5 +262,5 @@ with tempfile.NamedTemporaryFile("w+", dir=conv_dir) as tf:
             os.unlink(log_out)
         os.link(tf.name, log_out)
     else:
-        with open(log_out, "w") as outfile:
+        with open(log_out, "w", encoding="utf-8") as outfile:
             subprocess.run(["tac", "-s", ""], stdin=tf, stdout=outfile, check=True)


### PR DESCRIPTION
Thanks for this repo! It was very helpful to me. These changes include more detailed usage instructions and my workaround for the following error: 

Traceback (most recent call last):
  File "D:\Users\********\kbe.py", line 246, in <module>
    while next_page := outputmsgs(query, dest=tf):
                       ~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "D:\Users\********\kbe.py", line 236, in outputmsgs
    dest.write(f"#{mid} - {sent_at_str} - {out}\n\0")
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python313\Lib\tempfile.py", line 499, in func_wrapper
    return func(*args, **kwargs)
  File "C:\Python313\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f4af' in position 43: character maps to <undefined>